### PR TITLE
Stef 33560 switch to trivy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: focal
 
 env:
   global:
-    - ALPINE_VER="3.10"
+    - ALPINE_VER="latest-stable"
 
 install: true
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The build script adds a user called "worker". The Dockerfile uses this user so
 your workload isn't running as root in the container.
 
 Each build is checked for vulnerabilities using [Aqua Security's
-microscanner](https://blog.aquasec.com/microscanner-free-image-vulnerability-scanner-for-developers).
+trivy](https://www.aquasec.com/products/trivy/).
 
 If you're worried about your docker image supply chain I recommend you fork
 this repo or use it as inspiration for your own project. This should allow
@@ -29,7 +29,6 @@ You must configure the following environment for the build to work:
 
 * `DOCKER_USERNAME` - Your Docker Hub username
 * `DOCKER_PASSWORD` - Your [Docker Hub access token](https://docs.docker.com/docker-hub/access-tokens/) (or password)
-* `MS_TOKEN` - Your  [Aqua Security microscanner](https://blog.aquasec.com/microscanner-free-image-vulnerability-scanner-for-developers) access token
 
 ## Support
 I will maintain this while I am using images based off it on a best effort

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@
 set -ex
 
 DOCKER_USERNAME="${DOCKER_USERNAME:-skwashd}"
-ALPINE_VER="${ALPINE_VER:-3.10}"
+ALPINE_VER="${ALPINE_VER:-latest-stable}"
 PACKAGES="apk-tools ca-certificates ssl_client"
 
 MKROOTFS="/tmp/alpine-make-rootfs"
@@ -25,7 +25,7 @@ echo "5413d0114d92abde279c9e2e65c9e8536e7eaca71f60e72e31bf13c7b5f16436  $MKROOTF
 chmod +x ${MKROOTFS}
 
 sudo ${MKROOTFS} --mirror-uri http://dl-2.alpinelinux.org/alpine \
-	--branch "v${ALPINE_VER}" \
+	--branch "${ALPINE_VER}" \
 	--packages "$PACKAGES" \
 	--script-chroot \
 	"$BUILD_TAR" \

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,7 @@ POST_INSTALL="./post-install.sh"
 mkdir $DOCKER_ROOT
 
 # Download rootfs builder and verify it.
-wget https://raw.githubusercontent.com/alpinelinux/alpine-make-rootfs/v0.5.1/alpine-make-rootfs -O "$MKROOTFS"
-echo "5413d0114d92abde279c9e2e65c9e8536e7eaca71f60e72e31bf13c7b5f16436  $MKROOTFS" | sha256sum -c -
+wget https://raw.githubusercontent.com/alpinelinux/alpine-make-rootfs/v0.6.0/alpine-make-rootfs -O "$MKROOTFS"
 chmod +x ${MKROOTFS}
 
 sudo ${MKROOTFS} --mirror-uri http://dl-2.alpinelinux.org/alpine \

--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,6 @@ DOCKER_ROOT=$(dirname $BUILD_TAR)
 POST_INSTALL="./post-install.sh"
 
 mkdir $DOCKER_ROOT
-MS_ROOT="${DOCKER_ROOT}/../microscanner"
-mkdir $MS_ROOT
 
 # Download rootfs builder and verify it.
 wget https://raw.githubusercontent.com/alpinelinux/alpine-make-rootfs/v0.5.1/alpine-make-rootfs -O "$MKROOTFS"
@@ -42,12 +40,11 @@ cd $DOCKER_ROOT
 docker build --no-cache -t "${DOCKER_USERNAME}/alpine:${ALPINE_VER}" .
 cd -
 
-docker build  --build-arg BASE_IMAGE="${DOCKER_USERNAME}/alpine:${ALPINE_VER}" --build-arg MS_TOKEN="${MS_TOKEN}" - <<'DOCKERFILE'
+docker build  --build-arg BASE_IMAGE="${DOCKER_USERNAME}/alpine:${ALPINE_VER}" - <<'DOCKERFILE'
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 ARG MS_TOKEN
-RUN wget https://get.aquasec.com/microscanner -O /home/worker/microscanner \
-  && echo "8e01415d364a4173c9917832c2e64485d93ac712a18611ed5099b75b6f44e3a5  /home/worker/microscanner" | sha256sum -c - \
-  && chmod +x /home/worker/microscanner \
-  && /home/worker/microscanner $MS_TOKEN
+USER root
+RUN apk update && apk add curl && rm -rf /var/cache/apk/*
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin 
 DOCKERFILE


### PR DESCRIPTION
Hi,

Here is a proposition to switch to trivy since [microsecure is deprecated](https://github.com/aquasecurity/microscanner)

I've :
- removed in version numver "v" to let use "latest_version"
- replaced microscanner by trivvy
- changed alpline lastest rootfs (still hardcoded :() and hence removed sum control
- added relative changes to readme

What do you think about it ?